### PR TITLE
Fixing the Flash Fallback Loop

### DIFF
--- a/example/js/flash-fallback.js
+++ b/example/js/flash-fallback.js
@@ -10,6 +10,6 @@ $(document).ready(function() {
   // The element id of the Flash embed
   var atts = { id: "flash-fallback-video" };
   // All of the magic handled by SWFObject (http://code.google.com/p/swfobject/)
-  swfobject.embedSWF("http://www.youtube.com/apiplayer?video_id=ylLzyHk54Z0&version=3&autoplay=1&loop=1", 
+  swfobject.embedSWF("http://www.youtube.com/apiplayer?video_id=ylLzyHk54Z0&version=3&autoplay=1&loop=1&playlist=ylLzyHk54Z0", 
                      "flash-fallback", "100%", "100%", "9", null, null, params, atts);
 });


### PR DESCRIPTION
The YouTube video won't actually loop without the 'playlist' parameter.
The playlist parameter must be set to the same video ID.
